### PR TITLE
Fix opacity slider usability on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,19 +116,69 @@
 				z-index: 1001;
 				right: 0px;
 				bottom: 130px;
-				width: 30px;
+				width: 50px;
 				height: 150px;
 				display: none;
 				pointer-events: none;
 			}
 			#mobileOpacitySliderInput {
 				width: 150px;
+				height: 40px;
 				transform: rotate(-90deg);
-				transform-origin: 15px 15px;
+				transform-origin: 20px 20px;
 				position: absolute;
-				top: 100px;
-				left: -20px;
+				top: 90px;
+				left: -30px;
 				pointer-events: auto;
+				-webkit-appearance: none;
+				appearance: none;
+				background: transparent;
+				cursor: pointer;
+			}
+			/* Slider track styles */
+			#mobileOpacitySliderInput::-webkit-slider-track {
+				width: 100%;
+				height: 12px;
+				background: rgba(255, 255, 255, 0.3);
+				border: 2px solid rgba(0, 0, 0, 0.3);
+				border-radius: 6px;
+			}
+			#mobileOpacitySliderInput::-moz-range-track {
+				width: 100%;
+				height: 12px;
+				background: rgba(255, 255, 255, 0.3);
+				border: 2px solid rgba(0, 0, 0, 0.3);
+				border-radius: 6px;
+			}
+			/* Slider thumb styles - larger touch target */
+			#mobileOpacitySliderInput::-webkit-slider-thumb {
+				-webkit-appearance: none;
+				appearance: none;
+				width: 40px;
+				height: 40px;
+				background: #007bff;
+				border: 3px solid white;
+				border-radius: 50%;
+				cursor: pointer;
+				box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+			}
+			#mobileOpacitySliderInput::-moz-range-thumb {
+				width: 40px;
+				height: 40px;
+				background: #007bff;
+				border: 3px solid white;
+				border-radius: 50%;
+				cursor: pointer;
+				box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+			}
+			/* Active/pressed state for better feedback */
+			#mobileOpacitySliderInput:active::-webkit-slider-thumb {
+				background: #0056b3;
+				transform: scale(1.1);
+			}
+			#mobileOpacitySliderInput:active::-moz-range-thumb {
+				background: #0056b3;
+				transform: scale(1.1);
 			}
 			.layer-control-item input {
 				margin-right: 10px;


### PR DESCRIPTION
The opacity slider was difficult to use on mobile devices due to small touch targets. This commit significantly improves the mobile user experience:

- Increased slider container width from 30px to 50px
- Added 40px height to slider input for thicker track (becomes width when rotated)
- Custom styled track: 12px height with visible background and border
- Much larger thumb/handle: 40px circular button (up from ~12px default)
- Added visual feedback: blue color, white border, shadow, and press animation
- Cross-browser support with -webkit- and -moz- prefixes

The slider is now much easier to tap and drag on mobile devices.